### PR TITLE
Check for pip2 if pip isn't available in scripts/install_third_party.sh

### DIFF
--- a/scripts/install_third_party.sh
+++ b/scripts/install_third_party.sh
@@ -25,8 +25,12 @@ source $(dirname $0)/setup.sh || exit 1
 # Checking if pip is installed. If you are having
 # trouble, please ensure that you have pip installed (see "Installing Oppia"
 # on the Oppia developers' wiki page).
+PIP_CMD="pip"
 echo Checking if pip is installed on the local machine
-if ! type pip > /dev/null 2>&1 ; then
+if ! type $PIP_CMD > /dev/null 2>&1 ; then
+  echo "Unable to find 'pip'. Trying pip2 instead..."
+  PIP_CMD="pip2"
+  if ! type $PIP_CMD > /dev/null 2>&1 ; then
     echo ""
     echo "  Pip is required to install Oppia-ml dependencies, but pip wasn't"
     echo "  found on your local machine."
@@ -41,6 +45,7 @@ if ! type pip > /dev/null 2>&1 ; then
 
     # If pip is not installed, quit.
     exit 1
+  fi
 fi
 
 echo Installing third party libraries
@@ -55,7 +60,7 @@ while read -r line; do
   echo Checking if $NAME is installed in $LIB_PATH
   if [ ! -d "$LIB_PATH" ]; then
     echo Installing $NAME
-    pip install $NAME==$VERSION --target="$LIB_PATH"
+    $PIP_CMD install $NAME==$VERSION --target="$LIB_PATH"
   fi
 done < "$MANIFEST_FILE"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -68,12 +68,12 @@ if ! test_python_version $PYTHON_CMD; then
     echo "Could not find a suitable Python environment. Exiting."
     # If OS is Windows, print helpful error message about adding Python to path.
     if [ ! "${OS}" == "Darwin" -a ! "${OS}" == "Linux" ]; then
-        echo "It looks like you are using Windows. If you have Python installed,"
-        echo "make sure it is in your PATH and that PYTHONPATH is set."
-        echo "If you have two versions of Python (ie, Python 2.7 and 3), specify 2.7 before other versions of Python when setting the PATH."
-        echo "Here are some helpful articles:"
-        echo "http://docs.python-guide.org/en/latest/starting/install/win/"
-        echo "https://stackoverflow.com/questions/3701646/how-to-add-to-the-pythonpath-in-windows-7"
+      echo "It looks like you are using Windows. If you have Python installed,"
+      echo "make sure it is in your PATH and that PYTHONPATH is set."
+      echo "If you have two versions of Python (ie, Python 2.7 and 3), specify 2.7 before other versions of Python when setting the PATH."
+      echo "Here are some helpful articles:"
+      echo "http://docs.python-guide.org/en/latest/starting/install/win/"
+      echo "https://stackoverflow.com/questions/3701646/how-to-add-to-the-pythonpath-in-windows-7"
     fi
     # Exit when no suitable Python environment can be found.
     return 1


### PR DESCRIPTION
I faced this problem in Arch linux. Ubuntu has `python` and `pip` command and they refer to `python2` and `pip2` by default. But Arch does not have those command and thus we have to use `python2.7` and `pip2`. We already have check for `python2.7`, this PR adds a similar check for `pip2`.