### PR TITLE
Sort the dict before generating signature.

### DIFF
--- a/core/services/remote_access_services.py
+++ b/core/services/remote_access_services.py
@@ -68,7 +68,7 @@ def generate_signature(data):
     Returns:
         str. The digital signature generated from request data.
     """
-    msg = json.dumps(data)
+    msg = json.dumps(sorted(data))
     key = _get_shared_secret()
 
     # Generate signature and return it.

--- a/core/services/remote_access_services.py
+++ b/core/services/remote_access_services.py
@@ -68,7 +68,7 @@ def generate_signature(data):
     Returns:
         str. The digital signature generated from request data.
     """
-    msg = json.dumps({key: data[key] for key in sorted(data)})
+    msg = json.dumps(data, sort_keys=True)
     key = _get_shared_secret()
 
     # Generate signature and return it.

--- a/core/services/remote_access_services.py
+++ b/core/services/remote_access_services.py
@@ -68,7 +68,7 @@ def generate_signature(data):
     Returns:
         str. The digital signature generated from request data.
     """
-    msg = json.dumps(sorted(data))
+    msg = json.dumps({key: data[key] for key in sorted(data)})
     key = _get_shared_secret()
 
     # Generate signature and return it.


### PR DESCRIPTION
Yesterday I was having chat with Pranav and we realized that `json.dumps()` and `json.loads()` do not maintain the order of the keys inside the dict.

As we know there is no order of keys in dict in python. To explain the issue here, consider a dict `{'a': 1, 'b': 2}`. It can be represented in 2 ways: `{'a': 1, 'b': 2}` or `{'b': 2, 'a': 1}`. The signature we generate in these 2 forms is different.

Therefore if our sent data contains one ordering of keys and data received by the Oppia contains another ordering of keys, then even though data is same the signatures won't match. Therefore we need to use sorted(data) when generating signature, on Oppia and Oppia-ml.

Pranav has already taken care of this in Oppia in his current PR oppia/oppia#3559. This PR will fix this in Oppia-ml as well.