### PR TITLE
Fix #13: Fix metadata platform services.

### DIFF
--- a/core/platform/metadata/gce_metadata_services.py
+++ b/core/platform/metadata/gce_metadata_services.py
@@ -23,7 +23,7 @@ import requests
 # For more information check following link:
 # https://cloud.google.com/compute/docs/storing-retrieving-metadata
 METADATA_ATTRIBUTES_URL = (
-    'https://metadata.google.internal/computeMetadata/v1/instance/attributes/')
+    'http://metadata.google.internal/computeMetadata/v1/instance/attributes/')
 
 
 METADATA_HEADERS = {


### PR DESCRIPTION
A small mistake from my side. After paying close attention to urls for [metadata access](https://cloud.google.com/compute/docs/storing-retrieving-metadata) I found that I used `https` while it supports `http` only.