### PR TITLE
Convert all floating point numbers to string before sending to Oppia.

### DIFF
--- a/core/classifiers/TextClassifier/TextClassifier.py
+++ b/core/classifiers/TextClassifier/TextClassifier.py
@@ -136,8 +136,8 @@ class TextClassifier(base.BaseClassifier):
         allowed_svm_kernel_params_keys = [u'kernel', u'gamma', u'coef0',
                                           u'degree']
         allowed_svm_keys = [u'n_support', u'dual_coef', u'support_vectors',
-                            u'intercept', u'classes', u'probA', u'probB',
-                            u'kernel_params']
+                            u'intercept', u'classes', u'kernel_params',
+                            u'probA', u'probB']
 
         for key in allowed_top_level_keys:
             if key not in classifier_data:

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -137,6 +137,7 @@ def convert_float_numbers_to_string_in_classifier_data(classifier_data):
             elif isinstance(item, dict):
                 new_list.append(
                     convert_float_numbers_to_string_in_classifier_data(item))
+                is_any_value_float = True
             elif isinstance(item, (basestring, int)):
                 new_list.append(item)
             else:

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -20,6 +20,8 @@ import re
 
 import scipy
 
+import vmconf
+
 def extract_svm_parameters(clf):
     """Extract parameters from a trained SVC classifier.
 
@@ -72,16 +74,18 @@ def unicode_validator_for_classifier_data(classifier_data):
             string.
     """
     if isinstance(classifier_data, dict):
-        for k in classifier_data.keys():
+        for k in classifier_data:
             if isinstance(k, str):
                 raise Exception('Expected %s to be unicode but found str.' % k)
             unicode_validator_for_classifier_data(classifier_data[k])
-    if isinstance(classifier_data, list):
+    elif isinstance(classifier_data, list):
         for item in classifier_data:
             unicode_validator_for_classifier_data(item)
-    if isinstance(classifier_data, str):
+    elif isinstance(classifier_data, str):
         raise Exception(
             'Expected \'%s\' to be unicode but found str.' % classifier_data)
+    else:
+        return
 
 
 def convert_float_numbers_to_string_in_classifier_data(classifier_data):
@@ -101,7 +105,7 @@ def convert_float_numbers_to_string_in_classifier_data(classifier_data):
             an exception is raised to report the error. The classifier data
             must not include any string values which can be casted to float.
         Exception. If classifier data contains an object whose type is other
-            than integer, string, dict or list.
+            than integer, string, dict, floats or list.
 
     Returns:
         dict|list|string|int|float. Modified classifier data in which float
@@ -122,7 +126,7 @@ def convert_float_numbers_to_string_in_classifier_data(classifier_data):
     elif isinstance(classifier_data, float):
         return str(classifier_data)
     elif isinstance(classifier_data, basestring):
-        if re.match(r'^([-+]?\d+\.\d+)$', classifier_data):
+        if re.match(vmconf.FLOAT_VERIFIER_REGEX, classifier_data):
             # A float value must not be stored as a string in
             # classifier data.
             raise Exception(

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -87,15 +87,25 @@ def unicode_validator_for_classifier_data(classifier_data):
 def convert_float_numbers_to_string_in_classifier_data(classifier_data):
     """Converts all floating point numbers in classifier data to string.
 
+    The following function iterates through entire classifier data and converts
+    all float values to corresponding string values. At the same time, it also
+    verifies that none of the existing string values are convertible to float
+    values with the help of regex.
+
     Args:
-        classifier_data: dict|list. The original classifier data which needs
-            conversion of floats to strings.
+        classifier_data: dict|list|string|int|float. The original classifier
+            data which needs conversion of floats to strings.
+
+    Raises:
+        Exception. If any of the string values are convertible to float then
+            an exception is raised to report the error. The classifier data
+            must not include any string values which can be casted to float.
 
     Returns:
-        dict|list. Modified classifier data in which float values are converted
-            into strings and each dict/subdict is augmented with a special key
-            'float_values' which contains list of keys whose values have
-            undergone the transformation.
+        dict|list|string|int|float. Modified classifier data in which float
+            values are converted into strings and each dict/subdict is augmented
+            with a special key 'float_values' which contains list of keys whose
+            values have undergone the transformation.
     """
     if isinstance(classifier_data, dict):
         for k in classifier_data:

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -112,11 +112,12 @@ def convert_float_numbers_to_string_in_classifier_data(classifier_data):
             values are converted into strings.
     """
     if isinstance(classifier_data, dict):
+        classifier_data_with_stringified_floats = {}
         for k in classifier_data:
-            classifier_data[k] = (
+            classifier_data_with_stringified_floats[k] = (
                 convert_float_numbers_to_string_in_classifier_data(
                     classifier_data[k]))
-        return classifier_data
+        return classifier_data_with_stringified_floats
     elif isinstance(classifier_data, list):
         new_list = []
         for item in classifier_data:

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -18,7 +18,6 @@
 
 import scipy
 
-
 def extract_svm_parameters(clf):
     """Extract parameters from a trained SVC classifier.
 
@@ -60,15 +59,40 @@ def extract_svm_parameters(clf):
     }
 
 
-def unicode_validator_for_classifier_data(var):
+def unicode_validator_for_classifier_data(classifier_data):
     """Validates that incoming object contains unicode literal strings."""
-    if isinstance(var, dict):
-        for k in var.keys():
+    if isinstance(classifier_data, dict):
+        for k in classifier_data.keys():
             if isinstance(k, str):
                 raise Exception('Expected %s to be unicode but found str.' % k)
-            unicode_validator_for_classifier_data(var[k])
-    if isinstance(var, (list, set, tuple)):
-        for item in var:
+            unicode_validator_for_classifier_data(classifier_data[k])
+    if isinstance(classifier_data, (list, set, tuple)):
+        for item in classifier_data:
             unicode_validator_for_classifier_data(item)
-    if isinstance(var, str):
-        raise Exception('Expected \'%s\' to be unicode but found str.' % var)
+    if isinstance(classifier_data, str):
+        raise Exception(
+            'Expected \'%s\' to be unicode but found str.' % classifier_data)
+
+
+def convert_float_numbers_to_string_in_classifier_data(classifier_data):
+    """Converts all floating point numbers in classifier data to string."""
+    if isinstance(classifier_data, dict):
+        for k in classifier_data.keys():
+            if isinstance(classifier_data[k], float):
+                classifier_data[k] = str(classifier_data[k])
+            else:
+                classifier_data[k] = (
+                    convert_float_numbers_to_string_in_classifier_data(
+                        classifier_data[k]))
+        return classifier_data
+    elif isinstance(classifier_data, (list, set, tuple)):
+        new_list = []
+        for item in classifier_data:
+            if isinstance(item, float):
+                new_list.append(str(item))
+            else:
+                new_list.append(
+                    convert_float_numbers_to_string_in_classifier_data(
+                        item))
+        return type(classifier_data)(new_list)
+    return classifier_data

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -114,7 +114,7 @@ def make_sure_that_list_has_uniform_structure(data):
                     new_items.append(subitem)
             else:
                 raise Exception(
-                    'Exepcted all the values in list to be either stirngs, '
+                    'Expected all the values in list to be either strings, '
                     'floats, integers, lists or dicts but '
                     'received %s.' % type(item))
         current_items = new_items

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -60,13 +60,21 @@ def extract_svm_parameters(clf):
 
 
 def unicode_validator_for_classifier_data(classifier_data):
-    """Validates that incoming object contains unicode literal strings."""
+    """Validates that incoming object contains unicode literal strings.
+
+    Args:
+        classifier_data: *. The trained classifier model data.
+
+    Raises:
+        Exception. If any of the strings in classifier data is not a unicode
+            string.
+    """
     if isinstance(classifier_data, dict):
         for k in classifier_data.keys():
             if isinstance(k, str):
                 raise Exception('Expected %s to be unicode but found str.' % k)
             unicode_validator_for_classifier_data(classifier_data[k])
-    if isinstance(classifier_data, (list, set, tuple)):
+    if isinstance(classifier_data, list):
         for item in classifier_data:
             unicode_validator_for_classifier_data(item)
     if isinstance(classifier_data, str):

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -77,14 +77,27 @@ def unicode_validator_for_classifier_data(classifier_data):
 FLOAT_INDICATOR_KEY = 'float_values'
 
 
+# pylint: disable=too-many-branches
 def convert_float_numbers_to_string_in_classifier_data(classifier_data):
+    """Converts all floating point numbers in classifier data to string.
+
+    Args:
+        classifier_data: dict|list. The original classifier data which needs
+            conversion of floats to strings.
+
+    Returns:
+        Dict|List. Modified classifier data in which float values are converted
+            into strings and each dict/subdict is augmented with a special key
+            'float_values' which contains list of keys whose values have
+            undergone the transformation.
+    """
     if isinstance(classifier_data, dict):
         if FLOAT_INDICATOR_KEY in classifier_data:
             raise Exception(
                 'Classifier data already contains a %s key' %
                 FLOAT_INDICATOR_KEY)
         float_fields = []
-        for k in classifier_data.keys():
+        for k in classifier_data:
             if isinstance(classifier_data[k], (basestring, int)):
                 classifier_data[k] = classifier_data[k]
             elif isinstance(classifier_data[k], dict):

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -76,7 +76,7 @@ def unicode_validator_for_classifier_data(classifier_data):
 
 def find_all_string_values_in_classifier_data(classifier_data, parent_key=''):
     """Finds all keys in classifier data which contain only string values."""
-    join_key = lambda x, y: y if x else '%s.%s' % (x, y)
+    join_key = lambda x, y: y if not x else '%s.%s' % (x, y)
     key_list = []
     if isinstance(classifier_data, dict):
         for k in classifier_data.keys():
@@ -94,7 +94,7 @@ def find_all_string_values_in_classifier_data(classifier_data, parent_key=''):
             if isinstance(item, (set, list, tuple)):
                 ret_list = find_all_string_values_in_classifier_data(
                     item, parent_key)
-                if ret_list:
+                if not ret_list:
                     all_values_are_string = False
             elif not isinstance(item, (str, unicode)):
                 all_values_are_string = False

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -99,40 +99,30 @@ def convert_float_numbers_to_string_in_classifier_data(classifier_data):
     """
     if isinstance(classifier_data, dict):
         for k in classifier_data:
-            if isinstance(classifier_data[k], basestring) and re.match(
-                    r'^([-+]?\d+\.\d+)$', classifier_data[k]):
-                # A float value must not be stored as a string in
-                # classifier data.
-                raise Exception(
-                    'Error: Found a float value %s stored as string. Float '
-                    'values should not be stored as strings.' % (
-                        classifier_data[k]))
-            if isinstance(classifier_data[k], (dict, list)):
-                classifier_data[k] = (
-                    convert_float_numbers_to_string_in_classifier_data(
-                        classifier_data[k]))
-            if isinstance(classifier_data[k], float):
-                classifier_data[k] = str(classifier_data[k])
+            classifier_data[k] = (
+                convert_float_numbers_to_string_in_classifier_data(
+                    classifier_data[k]))
         return classifier_data
     elif isinstance(classifier_data, list):
         new_list = []
         for item in classifier_data:
-            if isinstance(item, (list, dict)):
-                new_list.append(
-                    convert_float_numbers_to_string_in_classifier_data(
-                        item))
-            if isinstance(item, float):
-                new_list.append(str(item))
-            if isinstance(item, basestring):
-                # A float value must not be stored as a string in
-                # classifier data.
-                if re.match(r'^([-+]?\d+\.\d+)$', item):
-                    raise Exception(
-                        'Error: Found a float value %s stored as string. Float '
-                        'values should not be stored as strings.' % (item))
-                new_list.append(item)
+            new_list.append(
+                convert_float_numbers_to_string_in_classifier_data(item))
         return new_list
+    elif isinstance(classifier_data, float):
+        return str(classifier_data)
+    elif isinstance(classifier_data, basestring):
+        if re.match(r'^([-+]?\d+\.\d+)$', classifier_data):
+            # A float value must not be stored as a string in
+            # classifier data.
+            raise Exception(
+                'Error: Found a float value %s stored as string. Float '
+                'values should not be stored as strings.' % (
+                    classifier_data))
+        return classifier_data
+    elif isinstance(classifier_data, int):
+        return classifier_data
     else:
         raise Exception(
-            'Expected all top-level classifier data objects to be lists or '
-            'dicts but received %s.' % (type(classifier_data)))
+            'Expected all classifier data objects to be lists, dicts, floats, '
+            'strings, integers but received %s.' % (type(classifier_data)))

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -105,7 +105,7 @@ def convert_float_numbers_to_string_in_classifier_data(classifier_data):
             an exception is raised to report the error. The classifier data
             must not include any string values which can be casted to float.
         Exception. If classifier data contains an object whose type is other
-            than integer, string, dict, floats or list.
+            than integer, string, dict, float or list.
 
     Returns:
         dict|list|string|int|float. Modified classifier data in which float

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -119,11 +119,11 @@ def convert_float_numbers_to_string_in_classifier_data(classifier_data):
                     classifier_data[k]))
         return classifier_data_with_stringified_floats
     elif isinstance(classifier_data, list):
-        new_list = []
+        classifier_data_with_stringified_floats = []
         for item in classifier_data:
-            new_list.append(
+            classifier_data_with_stringified_floats.append(
                 convert_float_numbers_to_string_in_classifier_data(item))
-        return new_list
+        return classifier_data_with_stringified_floats
     elif isinstance(classifier_data, float):
         return str(classifier_data)
     elif isinstance(classifier_data, basestring):

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -74,6 +74,41 @@ def unicode_validator_for_classifier_data(classifier_data):
             'Expected \'%s\' to be unicode but found str.' % classifier_data)
 
 
+def find_all_string_values_in_classifier_data(classifier_data, parent_key=''):
+    """Finds all keys in classifier data which contain only string values."""
+    join_key = lambda x, y: y if x else '%s.%s' % (x, y)
+    key_list = []
+    if isinstance(classifier_data, dict):
+        for k in classifier_data.keys():
+            if isinstance(classifier_data[k], (str, unicode)):
+                key_list.append(join_key(parent_key, k))
+            else:
+                ret_list = find_all_string_values_in_classifier_data(
+                    classifier_data[k], k)
+                if ret_list:
+                    key_list += [join_key(parent_key, key) for key in ret_list]
+        return key_list
+    elif isinstance(classifier_data, (set, list, tuple)):
+        all_values_are_string = True
+        for item in classifier_data:
+            if isinstance(item, (set, list, tuple)):
+                ret_list = find_all_string_values_in_classifier_data(
+                    item, parent_key)
+                if ret_list:
+                    all_values_are_string = False
+            elif not isinstance(item, (str, unicode)):
+                all_values_are_string = False
+            else:
+                key_list += find_all_string_values_in_classifier_data(
+                    item, parent_key)
+
+        if all_values_are_string:
+            return (
+                [join_key(parent_key, key) for key in key_list] + [parent_key])
+        return []
+    return key_list
+
+
 def convert_float_numbers_to_string_in_classifier_data(classifier_data):
     """Converts all floating point numbers in classifier data to string."""
     if isinstance(classifier_data, dict):

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -105,9 +105,7 @@ def convert_float_numbers_to_string_in_classifier_data(classifier_data):
 
     Returns:
         dict|list|string|int|float. Modified classifier data in which float
-            values are converted into strings and each dict/subdict is augmented
-            with a special key 'float_values' which contains list of keys whose
-            values have undergone the transformation.
+            values are converted into strings.
     """
     if isinstance(classifier_data, dict):
         for k in classifier_data:

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -100,6 +100,8 @@ def convert_float_numbers_to_string_in_classifier_data(classifier_data):
         Exception. If any of the string values are convertible to float then
             an exception is raised to report the error. The classifier data
             must not include any string values which can be casted to float.
+        Exception. If classifier data contains an object whose type is other
+            than integer, string, dict or list.
 
     Returns:
         dict|list|string|int|float. Modified classifier data in which float

--- a/core/classifiers/classifier_utils.py
+++ b/core/classifiers/classifier_utils.py
@@ -149,7 +149,7 @@ def convert_float_numbers_to_string_in_classifier_data(classifier_data):
             conversion of floats to strings.
 
     Returns:
-        Dict|List. Modified classifier data in which float values are converted
+        dict|list. Modified classifier data in which float values are converted
             into strings and each dict/subdict is augmented with a special key
             'float_values' which contains list of keys whose values have
             undergone the transformation.

--- a/core/classifiers/classifier_utils_test.py
+++ b/core/classifiers/classifier_utils_test.py
@@ -138,12 +138,11 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
             Exception, 'Expected \'f\' to be unicode but found str.'):
             classifier_utils.unicode_validator_for_classifier_data(test_dict)
 
-    def test_find_all_string_values_in_classifier_data(self):
-        """Make sure that all string value keys are identified correctly."""
+    def test_convert_float_numbers_to_string_in_classifier_data(self):
+        """Make sure that all values are converted correctly."""
         test_dict = {
             'a': {
                 'ab': 'abcd',
-                'ac': 0.5,
                 'ad': {
                     'ada': 'abcdef',
                     'adc': ['fghi', {
@@ -166,54 +165,36 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
             'c': 1.123432,
         }
 
-        expected_list = ['a.ab', 'a.ad.ada', 'a.ae', 'b.be.bea', 'b.bg']
-        output_list = (
-            classifier_utils.find_all_string_values_in_classifier_data(
-                test_dict))
-        self.assertListEqual(sorted(expected_list), sorted(output_list))
-
-    def test_convert_float_numbers_to_string_in_classifier_data(self):
-        """Make sure that all values are converted correctly."""
-        test_dict = {
-            'a': {
-                'ab': 'abcd',
-                'ac': 0.5
-            },
-            'b': {
-                'ba': [1, 2, 3],
-                'bb': [[1.0, 0.0, 1.0], [0.0, 1.0, 1.0]],
-                'bc': [-3.44757604341e-05, -3.44757604341e-05],
-                'bd': [-2.48521656693, -2.48521656693, -2.48521656693],
-                'be': {
-                    'bea': 'abcdef',
-                    'beb': 0.0,
-                    'bec': 0.142857142857,
-                    'bed': 3},
-                'bf': [0.133432545, 1, 2, 3.1233]
-            },
-            'c': 1.123432,
-            'd': 21123
-        }
-
         expected_dict = {
             'a': {
                 'ab': 'abcd',
-                'ac': '0.5'
+                'ad': {
+                    'ada': 'abcdef',
+                    'adc': ['fghi', {
+                        'adca': 'abcd',
+                        'adcb': '0.1234',
+                        'adcc': ['ade', 'afd'],
+                        'float_values': ['adcb']
+                    }],
+                    'float_values': []
+                },
+                'ae': [['123', '0.123'], ['abc']],
+                'af': [['abcde'], ['0.871']],
+                'float_values': ['af']
             },
             'b': {
-                'ba': [1, 2, 3],
-                'bb': [['1.0', '0.0', '1.0'], ['0.0', '1.0', '1.0']],
-                'bc': ['-3.44757604341e-05', '-3.44757604341e-05'],
                 'bd': ['-2.48521656693', '-2.48521656693', '-2.48521656693'],
                 'be': {
                     'bea': 'abcdef',
-                    'beb': '0.0',
-                    'bec': '0.142857142857',
-                    'bed': 3},
-                'bf': ['0.133432545', 1, 2, '3.1233']
+                    'bed': 3,
+                    'float_values': []
+                },
+                'bg': ['abc', 'def', 'ghi'],
+                'bh': ['abc', 123],
+                'float_values': ['bd']
             },
             'c': '1.123432',
-            'd': 21123
+            'float_values': ['c']
         }
 
         output_dict = (

--- a/core/classifiers/classifier_utils_test.py
+++ b/core/classifiers/classifier_utils_test.py
@@ -16,8 +16,11 @@
 
 """Tests for utility functions defined in classifier_utils."""
 
+import re
+
 from core.classifiers import classifier_utils
 from core.tests import test_utils
+import vmconf
 
 import numpy as np
 from sklearn import svm
@@ -137,6 +140,27 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             Exception, 'Expected \'f\' to be unicode but found str.'):
             classifier_utils.unicode_validator_for_classifier_data(test_dict)
+
+    def test_that_float_verifier_regex_works_correctly(self):
+        """Test that float verifier regex correctly identifies float values."""
+        test_list = [
+            '0.123', '+0.123', '-0.123', '.123', '+.123', '-.123',
+            '0000003.1']
+        for test in test_list:
+            self.assertEqual(
+                re.match(vmconf.FLOAT_VERIFIER_REGEX, test).groups()[0], test)
+
+        test_list = [
+            '3e10', '3e-10', '3e+10', '+3e10', '-3e10', '+3e+10', '+3e-10',
+            '-3e-10', '-3e+10', '0.3e10', '-0.3e10', '+0.3e10', '-0.3e-10',
+            '-0.3e+10', '+0.3e+10', '+0.3e-10', '.3e+10', '-.3e10']
+        for test in test_list:
+            self.assertEqual(
+                re.match(vmconf.FLOAT_VERIFIER_REGEX, test).groups()[1], test)
+
+        test_list = ['123', '0000', '123.']
+        for test in test_list:
+            self.assertIsNone(re.match(vmconf.FLOAT_VERIFIER_REGEX, test))
 
     def test_convert_float_numbers_to_string_in_classifier_data(self):
         """Make sure that all values are converted correctly."""

--- a/core/classifiers/classifier_utils_test.py
+++ b/core/classifiers/classifier_utils_test.py
@@ -158,7 +158,8 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
                 'bd': [-2.48521656693, -2.48521656693, -2.48521656693],
                 'be': {
                     'bea': 'abcdef',
-                    'bed': 3},
+                    'bed': 3
+                },
                 'bg': ['abc', 'def', 'ghi'],
                 'bh': ['abc', 123],
             },

--- a/core/classifiers/classifier_utils_test.py
+++ b/core/classifiers/classifier_utils_test.py
@@ -146,7 +146,6 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
 
         expected_dict = {
             'x': ['123', 'abc', '0.123'],
-            'float_values': ['x']
         }
 
         output_dict = (
@@ -206,21 +205,16 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
                         'adca': 'abcd',
                         'adcb': '0.1234',
                         'adcc': ['ade', 'afd'],
-                        'float_values': ['adcb']
                     }],
-                    'float_values': ['adc']
                 },
                 'ae': [['123', '0.123'], ['abc']],
-                'float_values': ['ae']
             },
             'b': {
                 'bd': ['-2.48521656693', '-2.48521656693', '-2.48521656693'],
                 'bg': ['abc', 'def', 'ghi'],
                 'bh': ['abc', '123'],
-                'float_values': ['bd']
             },
             'c': '1.123432',
-            'float_values': ['c']
         }
 
         output_dict = (

--- a/core/classifiers/classifier_utils_test.py
+++ b/core/classifiers/classifier_utils_test.py
@@ -138,79 +138,44 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
             Exception, 'Expected \'f\' to be unicode but found str.'):
             classifier_utils.unicode_validator_for_classifier_data(test_dict)
 
-    def test_that_nonuniform_lists_are_identified(self):
-        """Make sure that only uniform structured lists are allowed."""
-        test_list = [1, 2, 3]
-        classifier_utils.make_sure_that_list_has_uniform_structure(test_list)
-
-        test_list = [[1], [2], [3]]
-        classifier_utils.make_sure_that_list_has_uniform_structure(test_list)
-
-        test_list = [[{'a': 1}], [{'a': 2}], [{'a': 1}]]
-        classifier_utils.make_sure_that_list_has_uniform_structure(test_list)
-
-        test_list = [1, 2, '3']
-        with self.assertRaisesRegexp(
-            Exception, 'Expected all the values in list to have same type.'):
-            classifier_utils.make_sure_that_list_has_uniform_structure(
-                test_list)
-
-        test_list = [1, 2, [3]]
-        with self.assertRaisesRegexp(
-            Exception, 'Expected all the values in list to have same type.'):
-            classifier_utils.make_sure_that_list_has_uniform_structure(
-                test_list)
-
-        test_list = [[1], ['2'], [3]]
-        with self.assertRaisesRegexp(
-            Exception, 'Expected all the values in list to have same type.'):
-            classifier_utils.make_sure_that_list_has_uniform_structure(
-                test_list)
-
-        test_list = [1, 2, 0.32]
-        with self.assertRaisesRegexp(
-            Exception, 'Expected all the values in list to have same type.'):
-            classifier_utils.make_sure_that_list_has_uniform_structure(
-                test_list)
-
-        test_list = [1, 2, [{'a': 1}]]
-        with self.assertRaisesRegexp(
-            Exception, 'Expected all the values in list to have same type.'):
-            classifier_utils.make_sure_that_list_has_uniform_structure(
-                test_list)
-
-        test_list = [[{'a': 0.12}], [{'a': 2}], [{'a': 1}]]
-        with self.assertRaisesRegexp(
-            Exception,
-            'Expected all the subdicts to have same set of keys '
-            'and corresponding value types.'):
-            classifier_utils.make_sure_that_list_has_uniform_structure(
-                test_list)
-
-        test_list = [[{'b': 4}], [{'a': 2}], [{'a': 1}]]
-        with self.assertRaisesRegexp(
-            Exception,
-            'Expected all the subdicts to have same set of keys '
-            'and corresponding value types.'):
-            classifier_utils.make_sure_that_list_has_uniform_structure(
-                test_list)
-
-        test_list = [[{'b': 4}], [{'a': 2}], [[{'a': 1}]]]
-        with self.assertRaisesRegexp(
-            Exception, 'Expected all the values in list to have same type.'):
-            classifier_utils.make_sure_that_list_has_uniform_structure(
-                test_list)
-
-        test_list = [[{'a': 4, 'b': 2}], [{'a': 2}], [{'a': 1}]]
-        with self.assertRaisesRegexp(
-            Exception,
-            'Expected all the subdicts to have same set of keys '
-            'and corresponding value types.'):
-            classifier_utils.make_sure_that_list_has_uniform_structure(
-                test_list)
-
     def test_convert_float_numbers_to_string_in_classifier_data(self):
         """Make sure that all values are converted correctly."""
+        test_dict = {
+            'x': ['123', 'abc', 0.123]
+        }
+
+        expected_dict = {
+            'x': ['123', 'abc', '0.123'],
+            'float_values': ['x']
+        }
+
+        output_dict = (
+            classifier_utils.convert_float_numbers_to_string_in_classifier_data(
+                test_dict))
+
+        self.assertDictEqual(expected_dict, output_dict)
+
+        test_dict = {
+            'x': '-0.123'
+        }
+
+        with self.assertRaisesRegexp(
+            Exception,
+            'Float values should not be stored as strings.'):
+            classifier_utils.convert_float_numbers_to_string_in_classifier_data(
+                test_dict)
+
+
+        test_dict = {
+            'x': ['+0.123', 0.456]
+        }
+
+        with self.assertRaisesRegexp(
+            Exception,
+            'Float values should not be stored as strings.'):
+            classifier_utils.convert_float_numbers_to_string_in_classifier_data(
+                test_dict)
+
         test_dict = {
             'a': {
                 'ab': 'abcd',
@@ -220,21 +185,12 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
                         'adca': 'abcd',
                         'adcb': 0.1234,
                         'adcc': ['ade', 'afd']
-                    }, {
-                        'adca': 'abce',
-                        'adcb': 0.34,
-                        'adcc': []
                     }]
                 },
-                'ae': [['123', '0.123'], ['abc']],
-                'af': [['abcde'], ['0.871']]
+                'ae': [['123', 0.123], ['abc']],
             },
             'b': {
                 'bd': [-2.48521656693, -2.48521656693, -2.48521656693],
-                'be': {
-                    'bea': 'abcdef',
-                    'bed': 3
-                },
                 'bg': ['abc', 'def', 'ghi'],
                 'bh': ['abc', '123'],
             },
@@ -251,25 +207,14 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
                         'adcb': '0.1234',
                         'adcc': ['ade', 'afd'],
                         'float_values': ['adcb']
-                    }, {
-                        'adca': 'abce',
-                        'adcb': '0.34',
-                        'adcc': [],
-                        'float_values': ['adcb']
                     }],
                     'float_values': ['adc']
                 },
                 'ae': [['123', '0.123'], ['abc']],
-                'af': [['abcde'], ['0.871']],
-                'float_values': []
+                'float_values': ['ae']
             },
             'b': {
                 'bd': ['-2.48521656693', '-2.48521656693', '-2.48521656693'],
-                'be': {
-                    'bea': 'abcdef',
-                    'bed': 3,
-                    'float_values': []
-                },
                 'bg': ['abc', 'def', 'ghi'],
                 'bh': ['abc', '123'],
                 'float_values': ['bd']

--- a/core/classifiers/classifier_utils_test.py
+++ b/core/classifiers/classifier_utils_test.py
@@ -137,3 +137,52 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
         with self.assertRaisesRegexp(
             Exception, 'Expected \'f\' to be unicode but found str.'):
             classifier_utils.unicode_validator_for_classifier_data(test_dict)
+
+    def test_convert_float_numbers_to_string_in_classifier_data(self):
+        """Make sure that all values are converted correctly."""
+        test_dict = {
+            'a': {
+                'ab': 'abcd',
+                'ac': 0.5
+            },
+            'b': {
+                'ba': [1, 2, 3],
+                'bb': [[1.0, 0.0, 1.0], [0.0, 1.0, 1.0]],
+                'bc': [-3.44757604341e-05, -3.44757604341e-05],
+                'bd': [-2.48521656693, -2.48521656693, -2.48521656693],
+                'be': {
+                    'bea': 'abcdef',
+                    'beb': 0.0,
+                    'bec': 0.142857142857,
+                    'bed': 3},
+                'bf': [0.133432545, 1, 2, 3.1233]
+            },
+            'c': 1.123432,
+            'd': 21123
+        }
+
+        expected_dict = {
+            'a': {
+                'ab': 'abcd',
+                'ac': '0.5'
+            },
+            'b': {
+                'ba': [1, 2, 3],
+                'bb': [['1.0', '0.0', '1.0'], ['0.0', '1.0', '1.0']],
+                'bc': ['-3.44757604341e-05', '-3.44757604341e-05'],
+                'bd': ['-2.48521656693', '-2.48521656693', '-2.48521656693'],
+                'be': {
+                    'bea': 'abcdef',
+                    'beb': '0.0',
+                    'bec': '0.142857142857',
+                    'bed': 3},
+                'bf': ['0.133432545', 1, 2, '3.1233']
+            },
+            'c': '1.123432',
+            'd': 21123
+        }
+
+        output_dict = (
+            classifier_utils.convert_float_numbers_to_string_in_classifier_data(
+                test_dict))
+        self.assertDictEqual(expected_dict, output_dict)

--- a/core/classifiers/classifier_utils_test.py
+++ b/core/classifiers/classifier_utils_test.py
@@ -138,6 +138,40 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
             Exception, 'Expected \'f\' to be unicode but found str.'):
             classifier_utils.unicode_validator_for_classifier_data(test_dict)
 
+    def test_find_all_string_values_in_classifier_data(self):
+        """Make sure that all string value keys are identified correctly."""
+        test_dict = {
+            'a': {
+                'ab': 'abcd',
+                'ac': 0.5,
+                'ad': {
+                    'ada': 'abcdef',
+                    'adc': ['fghi', {
+                        'adca': 'abcd',
+                        'adcb': 0.1234,
+                        'adcc': ['ade', 'afd']
+                    }]
+                },
+                'ae': [['123', '0.123'], ['abc']],
+                'af': [['abcde'], [0.871]]
+            },
+            'b': {
+                'bd': [-2.48521656693, -2.48521656693, -2.48521656693],
+                'be': {
+                    'bea': 'abcdef',
+                    'bed': 3},
+                'bg': ['abc', 'def', 'ghi'],
+                'bh': ['abc', 123],
+            },
+            'c': 1.123432,
+        }
+
+        expected_list = ['a.ab', 'a.ad.ada', 'a.ae', 'b.be.bea', 'b.bg']
+        output_list = (
+            classifier_utils.find_all_string_values_in_classifier_data(
+                test_dict))
+        self.assertListEqual(sorted(expected_list), sorted(output_list))
+
     def test_convert_float_numbers_to_string_in_classifier_data(self):
         """Make sure that all values are converted correctly."""
         test_dict = {

--- a/core/classifiers/classifier_utils_test.py
+++ b/core/classifiers/classifier_utils_test.py
@@ -177,7 +177,7 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
                         'adcc': ['ade', 'afd'],
                         'float_values': ['adcb']
                     }],
-                    'float_values': []
+                    'float_values': ['adc']
                 },
                 'ae': [['123', '0.123'], ['abc']],
                 'af': [['abcde'], ['0.871']],

--- a/core/classifiers/classifier_utils_test.py
+++ b/core/classifiers/classifier_utils_test.py
@@ -138,6 +138,77 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
             Exception, 'Expected \'f\' to be unicode but found str.'):
             classifier_utils.unicode_validator_for_classifier_data(test_dict)
 
+    def test_that_nonuniform_lists_are_identified(self):
+        """Make sure that only uniform structured lists are allowed."""
+        test_list = [1, 2, 3]
+        classifier_utils.make_sure_that_list_has_uniform_structure(test_list)
+
+        test_list = [[1], [2], [3]]
+        classifier_utils.make_sure_that_list_has_uniform_structure(test_list)
+
+        test_list = [[{'a': 1}], [{'a': 2}], [{'a': 1}]]
+        classifier_utils.make_sure_that_list_has_uniform_structure(test_list)
+
+        test_list = [1, 2, '3']
+        with self.assertRaisesRegexp(
+            Exception, 'Expected all the values in list to have same type.'):
+            classifier_utils.make_sure_that_list_has_uniform_structure(
+                test_list)
+
+        test_list = [1, 2, [3]]
+        with self.assertRaisesRegexp(
+            Exception, 'Expected all the values in list to have same type.'):
+            classifier_utils.make_sure_that_list_has_uniform_structure(
+                test_list)
+
+        test_list = [[1], ['2'], [3]]
+        with self.assertRaisesRegexp(
+            Exception, 'Expected all the values in list to have same type.'):
+            classifier_utils.make_sure_that_list_has_uniform_structure(
+                test_list)
+
+        test_list = [1, 2, 0.32]
+        with self.assertRaisesRegexp(
+            Exception, 'Expected all the values in list to have same type.'):
+            classifier_utils.make_sure_that_list_has_uniform_structure(
+                test_list)
+
+        test_list = [1, 2, [{'a': 1}]]
+        with self.assertRaisesRegexp(
+            Exception, 'Expected all the values in list to have same type.'):
+            classifier_utils.make_sure_that_list_has_uniform_structure(
+                test_list)
+
+        test_list = [[{'a': 0.12}], [{'a': 2}], [{'a': 1}]]
+        with self.assertRaisesRegexp(
+            Exception,
+            'Expected all the subdicts to have same set of keys '
+            'and corresponding value types.'):
+            classifier_utils.make_sure_that_list_has_uniform_structure(
+                test_list)
+
+        test_list = [[{'b': 4}], [{'a': 2}], [{'a': 1}]]
+        with self.assertRaisesRegexp(
+            Exception,
+            'Expected all the subdicts to have same set of keys '
+            'and corresponding value types.'):
+            classifier_utils.make_sure_that_list_has_uniform_structure(
+                test_list)
+
+        test_list = [[{'b': 4}], [{'a': 2}], [[{'a': 1}]]]
+        with self.assertRaisesRegexp(
+            Exception, 'Expected all the values in list to have same type.'):
+            classifier_utils.make_sure_that_list_has_uniform_structure(
+                test_list)
+
+        test_list = [[{'a': 4, 'b': 2}], [{'a': 2}], [{'a': 1}]]
+        with self.assertRaisesRegexp(
+            Exception,
+            'Expected all the subdicts to have same set of keys '
+            'and corresponding value types.'):
+            classifier_utils.make_sure_that_list_has_uniform_structure(
+                test_list)
+
     def test_convert_float_numbers_to_string_in_classifier_data(self):
         """Make sure that all values are converted correctly."""
         test_dict = {
@@ -145,14 +216,18 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
                 'ab': 'abcd',
                 'ad': {
                     'ada': 'abcdef',
-                    'adc': ['fghi', {
+                    'adc': [{
                         'adca': 'abcd',
                         'adcb': 0.1234,
                         'adcc': ['ade', 'afd']
+                    }, {
+                        'adca': 'abce',
+                        'adcb': 0.34,
+                        'adcc': []
                     }]
                 },
                 'ae': [['123', '0.123'], ['abc']],
-                'af': [['abcde'], [0.871]]
+                'af': [['abcde'], ['0.871']]
             },
             'b': {
                 'bd': [-2.48521656693, -2.48521656693, -2.48521656693],
@@ -161,7 +236,7 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
                     'bed': 3
                 },
                 'bg': ['abc', 'def', 'ghi'],
-                'bh': ['abc', 123],
+                'bh': ['abc', '123'],
             },
             'c': 1.123432,
         }
@@ -171,17 +246,22 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
                 'ab': 'abcd',
                 'ad': {
                     'ada': 'abcdef',
-                    'adc': ['fghi', {
+                    'adc': [{
                         'adca': 'abcd',
                         'adcb': '0.1234',
                         'adcc': ['ade', 'afd'],
+                        'float_values': ['adcb']
+                    }, {
+                        'adca': 'abce',
+                        'adcb': '0.34',
+                        'adcc': [],
                         'float_values': ['adcb']
                     }],
                     'float_values': ['adc']
                 },
                 'ae': [['123', '0.123'], ['abc']],
                 'af': [['abcde'], ['0.871']],
-                'float_values': ['af']
+                'float_values': []
             },
             'b': {
                 'bd': ['-2.48521656693', '-2.48521656693', '-2.48521656693'],
@@ -191,7 +271,7 @@ class ClassifierUtilsTest(test_utils.GenericTestBase):
                     'float_values': []
                 },
                 'bg': ['abc', 'def', 'ghi'],
-                'bh': ['abc', 123],
+                'bh': ['abc', '123'],
                 'float_values': ['bd']
             },
             'c': '1.123432',

--- a/core/services/job_services.py
+++ b/core/services/job_services.py
@@ -117,6 +117,7 @@ def store_job_result(job_id, classifier_data):
     # numbers are represented differently on GAE(Oppia) and GCE(Oppia-ml).
     # Therefore, converting all floating point numbers to string keeps
     # signature consistent on both Oppia and Oppia-ml.
+    # For more info visit: https://stackoverflow.com/q/40173295
     strings_only_key_list = (
         classifier_utils.find_all_string_values_in_classifier_data(
             classifier_data))

--- a/core/services/job_services.py
+++ b/core/services/job_services.py
@@ -17,6 +17,7 @@
 """This module contains functions used for polling, training and saving jobs."""
 
 from core.classifiers import algorithm_registry
+from core.classifiers import classifier_utils
 from core.services import remote_access_services
 
 # pylint: disable=too-many-branches
@@ -111,6 +112,14 @@ def store_job_result(job_id, classifier_data):
     Returns:
         int. Status code of response.
     """
+    # The classifier data to be sent in the payload should have all
+    # floating point values stored as strings. This is because floating point
+    # numbers are represented differently on GAE(Oppia) and GCE(Oppia-ml).
+    # Therefore, converting all floating point numbers to string keeps
+    # signature consistent on both Oppia and Oppia-ml.
+    classifier_data = (
+        classifier_utils.convert_float_numbers_to_string_in_classifier_data(
+            classifier_data))
     job_result_dict = {
         'job_id': job_id,
         'classifier_data': classifier_data

--- a/core/services/job_services.py
+++ b/core/services/job_services.py
@@ -118,12 +118,12 @@ def store_job_result(job_id, classifier_data):
     # Therefore, converting all floating point numbers to string keeps
     # signature consistent on both Oppia and Oppia-ml.
     # For more info visit: https://stackoverflow.com/q/40173295
-    classifier_data = (
+    classifier_data_with_stringified_floats = (
         classifier_utils.convert_float_numbers_to_string_in_classifier_data(
             classifier_data))
     job_result_dict = {
         'job_id': job_id,
-        'classifier_data': classifier_data
+        'classifier_data': classifier_data_with_stringified_floats
     }
 
     status = remote_access_services.store_trained_classifier_model(

--- a/core/services/job_services.py
+++ b/core/services/job_services.py
@@ -117,9 +117,13 @@ def store_job_result(job_id, classifier_data):
     # numbers are represented differently on GAE(Oppia) and GCE(Oppia-ml).
     # Therefore, converting all floating point numbers to string keeps
     # signature consistent on both Oppia and Oppia-ml.
+    strings_only_key_list = (
+        classifier_utils.find_all_string_values_in_classifier_data(
+            classifier_data))
     classifier_data = (
         classifier_utils.convert_float_numbers_to_string_in_classifier_data(
             classifier_data))
+    classifier_data['strings_only_key_list'] = strings_only_key_list
     job_result_dict = {
         'job_id': job_id,
         'classifier_data': classifier_data

--- a/core/services/job_services.py
+++ b/core/services/job_services.py
@@ -118,13 +118,9 @@ def store_job_result(job_id, classifier_data):
     # Therefore, converting all floating point numbers to string keeps
     # signature consistent on both Oppia and Oppia-ml.
     # For more info visit: https://stackoverflow.com/q/40173295
-    strings_only_key_list = (
-        classifier_utils.find_all_string_values_in_classifier_data(
-            classifier_data))
     classifier_data = (
         classifier_utils.convert_float_numbers_to_string_in_classifier_data(
             classifier_data))
-    classifier_data['strings_only_key_list'] = strings_only_key_list
     job_result_dict = {
         'job_id': job_id,
         'classifier_data': classifier_data

--- a/core/services/remote_access_services.py
+++ b/core/services/remote_access_services.py
@@ -126,7 +126,8 @@ def store_trained_classifier_model(job_result_dict):
         raise Exception('job_result_dict must contain \'job_id\'.')
 
     if 'classifier_data' not in job_result_dict:
-        raise Exception('job_result_dict must contain \'classifier_data\'.')
+        raise Exception(
+            'job_result_dict must contain \'classifier_data\'.')
 
     payload = {
         'message': job_result_dict,

--- a/core/services/remote_access_services_test.py
+++ b/core/services/remote_access_services_test.py
@@ -82,7 +82,8 @@ class RemoteAccessServicesTests(test_utils.GenericTestBase):
                 'param': 'val'
             }
             self.assertDictEqual(
-                classifier_data, request.payload['message']['classifier_data'])
+                classifier_data,
+                request.payload['message']['classifier_data'])
 
         with self.set_job_result_post_callback(post_callback):
             status = remote_access_services.store_trained_classifier_model(
@@ -110,6 +111,7 @@ class RemoteAccessServicesTests(test_utils.GenericTestBase):
         }
 
         with self.assertRaisesRegexp(
-            Exception, 'job_result_dict must contain \'classifier_data\'.'):
+            Exception,
+            'job_result_dict must contain \'classifier_data\'.'):
             remote_access_services.store_trained_classifier_model(
                 job_result_dict)

--- a/vmconf.py
+++ b/vmconf.py
@@ -85,4 +85,5 @@ XSSI_PREFIX = ')]}\'\n'
 
 # The regular expression used to identify whether a string contains float value.
 # The regex must match with regex that is stored in feconf.py file of Oppia.
-FLOAT_VERIFIER_REGEX = '^([-+]?\\d*\\.\\d+)$|^([-+]?\\d+\\.?\\d*e[-+]?\\d*)$'
+FLOAT_VERIFIER_REGEX = (
+    '^([-+]?\\d*\\.\\d+)$|^([-+]?(\\d*\\.?\\d+|\\d+\\.?\\d*)e[-+]?\\d*)$')

--- a/vmconf.py
+++ b/vmconf.py
@@ -82,3 +82,9 @@ DEFAULT_WAITING_METHOD = FIXED_TIME_WAITING
 
 # Prefix for data sent from Oppia to the Oppia-ml via JSON.
 XSSI_PREFIX = ')]}\'\n'
+
+# Each dict/subdict in classifier data should contain following key which
+# stores a list of keys whose values should undergo transformation on Oppia.
+# The value of following constant must be same with corresponding constant
+# on Oppia stored at core/domain/classifier_services.py file.
+FLOAT_INDICATOR_KEY = 'float_values'

--- a/vmconf.py
+++ b/vmconf.py
@@ -85,4 +85,4 @@ XSSI_PREFIX = ')]}\'\n'
 
 # The regular expression used to identify whether a string contains float value.
 # The regex must match with regex that is stored in feconf.py file of Oppia.
-FLOAT_VERIFIER_REGEX = '^([-+]?\\d*\\.\\d+)$|^([-+]?\\d+\\.\\d*e[-+]?\\d*)$'
+FLOAT_VERIFIER_REGEX = '^([-+]?\\d*\\.\\d+)$|^([-+]?\\d+\\.?\\d*e[-+]?\\d*)$'

--- a/vmconf.py
+++ b/vmconf.py
@@ -85,5 +85,9 @@ XSSI_PREFIX = ')]}\'\n'
 
 # The regular expression used to identify whether a string contains float value.
 # The regex must match with regex that is stored in feconf.py file of Oppia.
+# If this regex needs to be modified then first of all shutdown Oppia-ml VM.
+# Then update the regex constant in here and Oppia both.
+# Run any migration job that is required to migrate existing trained models
+# before starting Oppia-ml again.
 FLOAT_VERIFIER_REGEX = (
     '^([-+]?\\d*\\.\\d+)$|^([-+]?(\\d*\\.?\\d+|\\d+\\.?\\d*)e[-+]?\\d*)$')

--- a/vmconf.py
+++ b/vmconf.py
@@ -82,3 +82,7 @@ DEFAULT_WAITING_METHOD = FIXED_TIME_WAITING
 
 # Prefix for data sent from Oppia to the Oppia-ml via JSON.
 XSSI_PREFIX = ')]}\'\n'
+
+# The regular expression used to identify whether a string contains float value.
+# The regex must match with regex that is stored in feconf.py file of Oppia.
+FLOAT_VERIFIER_REGEX = '^([-+]?\\d*\\.\\d+)$|^([-+]?\\d+\\.\\d*e[-+]?\\d*)$'

--- a/vmconf.py
+++ b/vmconf.py
@@ -82,9 +82,3 @@ DEFAULT_WAITING_METHOD = FIXED_TIME_WAITING
 
 # Prefix for data sent from Oppia to the Oppia-ml via JSON.
 XSSI_PREFIX = ')]}\'\n'
-
-# Each dict/subdict in classifier data should contain following key which
-# stores a list of keys whose values should undergo transformation on Oppia.
-# The value of following constant must be same with corresponding constant
-# on Oppia stored at feconf.py file.
-FLOAT_INDICATOR_KEY = 'float_values'

--- a/vmconf.py
+++ b/vmconf.py
@@ -86,5 +86,5 @@ XSSI_PREFIX = ')]}\'\n'
 # Each dict/subdict in classifier data should contain following key which
 # stores a list of keys whose values should undergo transformation on Oppia.
 # The value of following constant must be same with corresponding constant
-# on Oppia stored at core/domain/classifier_services.py file.
+# on Oppia stored at feconf.py file.
 FLOAT_INDICATOR_KEY = 'float_values'


### PR DESCRIPTION
This PR adds code to convert all floating point values in classifier data to string before generating signature and sending it to Oppia. This is required because Oppia and Oppia-ml both use slightly [different representation for floating point numbers](https://stackoverflow.com/questions/40173295/float-formatting-json-dump-with-python-and-google-app-engine-issue). This allows us to keep signature consistent on both Oppia and Oppia-ml.