### PR TITLE
Migrate generate_signature method 

### DIFF
--- a/core/domain/remote_access_services.py
+++ b/core/domain/remote_access_services.py
@@ -93,8 +93,8 @@ def fetch_next_job_request():
         _get_url(), _get_port(), vmconf.FETCH_NEXT_JOB_REQUEST_HANDLER)
 
     payload = {
-        'vm_id': _get_vm_id().encode(),
-        'message': _get_vm_id().encode(),
+        'vm_id': _get_vm_id().encode('utf-8'),
+        'message': _get_vm_id().encode('utf-8'),
     }
     signature = generate_signature(payload['message'], payload['vm_id'])
     payload['signature'] = signature
@@ -119,8 +119,8 @@ def store_trained_classifier_model(job_result):
     job_result.validate()
     payload = training_job_response_payload_pb2.TrainingJobResponsePayload()
     payload.job_result.CopyFrom(job_result.to_proto())
-    payload.vm_id = _get_vm_id().encode()
-    message = payload.job_result.SerializeToString().encode()
+    payload.vm_id = _get_vm_id().encode('utf-8')
+    message = payload.job_result.SerializeToString().encode('utf-8')
     signature = generate_signature(message, payload.vm_id)
     payload.signature = signature
 

--- a/core/domain/remote_access_services.py
+++ b/core/domain/remote_access_services.py
@@ -93,8 +93,8 @@ def fetch_next_job_request():
         _get_url(), _get_port(), vmconf.FETCH_NEXT_JOB_REQUEST_HANDLER)
 
     payload = {
-        'vm_id': _get_vm_id().encode('utf-8'),
-        'message': _get_vm_id().encode('utf-8'),
+        'vm_id': _get_vm_id().encode(encoding='utf-8'),
+        'message': _get_vm_id().encode(encoding='utf-8'),
     }
     signature = generate_signature(payload['message'], payload['vm_id'])
     payload['signature'] = signature
@@ -119,8 +119,8 @@ def store_trained_classifier_model(job_result):
     job_result.validate()
     payload = training_job_response_payload_pb2.TrainingJobResponsePayload()
     payload.job_result.CopyFrom(job_result.to_proto())
-    payload.vm_id = _get_vm_id().encode('utf-8')
-    message = payload.job_result.SerializeToString().encode('utf-8')
+    payload.vm_id = _get_vm_id().encode(encoding='utf-8')
+    message = payload.job_result.SerializeToString().encode(encoding='utf-8')
     signature = generate_signature(message, payload.vm_id)
     payload.signature = signature
 

--- a/core/domain/remote_access_services.py
+++ b/core/domain/remote_access_services.py
@@ -69,12 +69,13 @@ def generate_signature(message, vm_id):
 
     Args:
         message: bytes. Message string.
-        vm_id: bytes. ID of the VM that trained the job.
+        vm_id: str. ID of the VM that trained the job.
 
     Returns:
         str. The digital signature generated from request data.
     """
-    msg = b'%s|%s' % (base64.b64encode(message), vm_id)
+    encoded_vm_id = vm_id.encode(encoding='utf-8')
+    msg = b'%s|%s' % (base64.b64encode(message), encoded_vm_id)
     key = _get_shared_secret().encode(encoding='utf-8')
 
     # Generate signature and return it.

--- a/core/domain/remote_access_services.py
+++ b/core/domain/remote_access_services.py
@@ -75,7 +75,7 @@ def generate_signature(message, vm_id):
         str. The digital signature generated from request data.
     """
     msg = b'%s|%s' % (base64.b64encode(message), vm_id)
-    key = _get_shared_secret().encode()
+    key = _get_shared_secret().encode(encoding='utf-8')
 
     # Generate signature and return it.
     return hmac.new(key, msg, digestmod=hashlib.sha256).hexdigest()

--- a/core/domain/remote_access_services.py
+++ b/core/domain/remote_access_services.py
@@ -68,14 +68,14 @@ def generate_signature(message, vm_id):
     """Generates digital signature for given message combined with vm_id.
 
     Args:
-        message: str. Message string.
-        vm_id: str. ID of the VM that trained the job.
+        message: bytes. Message string.
+        vm_id: bytes. ID of the VM that trained the job.
 
     Returns:
         str. The digital signature generated from request data.
     """
-    msg = '%s|%s' % (base64.b64encode(message), vm_id)
-    key = _get_shared_secret()
+    msg = b'%s|%s' % (base64.b64encode(message), vm_id)
+    key = _get_shared_secret().encode()
 
     # Generate signature and return it.
     return hmac.new(key, msg, digestmod=hashlib.sha256).hexdigest()
@@ -93,8 +93,8 @@ def fetch_next_job_request():
         _get_url(), _get_port(), vmconf.FETCH_NEXT_JOB_REQUEST_HANDLER)
 
     payload = {
-        'vm_id': _get_vm_id(),
-        'message': _get_vm_id(),
+        'vm_id': _get_vm_id().encode(),
+        'message': _get_vm_id().encode(),
     }
     signature = generate_signature(payload['message'], payload['vm_id'])
     payload['signature'] = signature
@@ -119,9 +119,9 @@ def store_trained_classifier_model(job_result):
     job_result.validate()
     payload = training_job_response_payload_pb2.TrainingJobResponsePayload()
     payload.job_result.CopyFrom(job_result.to_proto())
-    payload.vm_id = _get_vm_id()
-    signature = generate_signature(
-        payload.job_result.SerializeToString(), payload.vm_id)
+    payload.vm_id = _get_vm_id().encode()
+    message = payload.job_result.SerializeToString().encode()
+    signature = generate_signature(message, payload.vm_id)
     payload.signature = signature
 
     data = payload.SerializeToString()

--- a/core/domain/remote_access_services_test.py
+++ b/core/domain/remote_access_services_test.py
@@ -37,7 +37,6 @@ class RemoteAccessServicesTests(test_utils.GenericTestBase):
         expected_signature = (
             '740ed25befc87674a82844db7769436edb7d21c29d1c9cc87d7a1f3fdefe3610')
         self.assertEqual(signature, expected_signature)
-        self.assertEqual(signature, "hi")
 
     def test_next_job_gets_fetched(self):
         """Test that next job is fetched correctly."""

--- a/core/domain/remote_access_services_test.py
+++ b/core/domain/remote_access_services_test.py
@@ -32,7 +32,7 @@ class RemoteAccessServicesTests(test_utils.GenericTestBase):
             message = 'vm_default'
             vm_id = 'vm_default'
             signature = remote_access_services.generate_signature(
-                message.encode(), vm_id.encode())
+                message.encode('utf-8'), vm_id.encode('utf-8'))
 
         expected_signature = (
             '740ed25befc87674a82844db7769436edb7d21c29d1c9cc87d7a1f3fdefe3610')

--- a/core/domain/remote_access_services_test.py
+++ b/core/domain/remote_access_services_test.py
@@ -32,7 +32,8 @@ class RemoteAccessServicesTests(test_utils.GenericTestBase):
             message = 'vm_default'
             vm_id = 'vm_default'
             signature = remote_access_services.generate_signature(
-                message.encode('utf-8'), vm_id.encode('utf-8'))
+                message.encode(encoding='utf-8'),
+                vm_id.encode(encoding='utf-8'))
 
         expected_signature = (
             '740ed25befc87674a82844db7769436edb7d21c29d1c9cc87d7a1f3fdefe3610')

--- a/core/domain/remote_access_services_test.py
+++ b/core/domain/remote_access_services_test.py
@@ -29,12 +29,15 @@ class RemoteAccessServicesTests(test_utils.GenericTestBase):
     def test_that_generate_signature_works_correctly(self):
         """Test that generate signature function is working as expected."""
         with self.swap(vmconf, 'DEFAULT_VM_SHARED_SECRET', '1a2b3c4e'):
+            message = 'vm_default'
+            vm_id = 'vm_default'
             signature = remote_access_services.generate_signature(
-                'vm_default', vm_id='vm_default')
+                message.encode(), vm_id.encode())
 
         expected_signature = (
             '740ed25befc87674a82844db7769436edb7d21c29d1c9cc87d7a1f3fdefe3610')
         self.assertEqual(signature, expected_signature)
+        self.assertEqual(signature, "hi")
 
     def test_next_job_gets_fetched(self):
         """Test that next job is fetched correctly."""


### PR DESCRIPTION
## Overview

1. This PR fixes [#12671](https://github.com/oppia/oppia/issues/12671) in oppia main repo.
2. This PR does the following: This PR modifies the generate_signature in the classifier_services so that it works in both python2 and python3. 

Note that there is an equivalent [PR](https://github.com/oppia/oppia/pull/12816) in the Oppia repository so both the PRs must be merged simultaneously.
